### PR TITLE
Enable automatic detection of Enshrouded save directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,14 @@ Run the script:
   python world_duplicator.py
   ```
 
-### **Using the program:**  
-- Click **"Select Save Folder"** to choose your Enshrouded save directory.  
-- Select a **source world** (the one you want to copy).  
-- Select a **target world** (the one you want to replace).  
-- Click **"Duplicate World"** to begin.  
+### **Using the program:**
+- The tool attempts to detect your save directory automatically on startup. It looks in:
+  - `%APPDATA%\\Roaming\\Enshrouded` (Windows)
+  - `~/.steam/steam/steamapps/compatdata/1203620/pfx/drive_c/users/steamuser/AppData/Roaming/Enshrouded` (Linux/Steam)
+- If detection fails, click **"Select Save Folder"** to choose your Enshrouded save directory.
+- Select a **source world** (the one you want to copy).
+- Select a **target world** (the one you want to replace).
+- Click **"Duplicate World"** to begin.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `guess_save_directory` helper to search common Windows and Linux locations for Enshrouded saves
- Auto-load detected save directory in GUI on startup
- Document automatic detection paths in README

## Testing
- `python -m py_compile world_duplicator.py`


------
https://chatgpt.com/codex/tasks/task_e_68add34f9948832cbe9eceb049a650f8