### PR TITLE
Add CLI interface for world duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,21 @@ Run the script:
   python world_duplicator.py
   ```
 
+### **Command-line usage**
+You can bypass the graphical interface and duplicate worlds directly from the command line:
+
+```shell
+python world_duplicator.py --source <world_id> --target <world_id>
+```
+
+Provide a custom save directory if it cannot be auto-detected:
+
+```shell
+python world_duplicator.py --source <src_id> --target <dst_id> --save-dir "/path/to/Enshrouded"
+```
+
+Both `--source` and `--target` must be valid world IDs. The script will report success or failure via the command line.
+
 ### **Using the program:**
 - The tool attempts to detect your save directory automatically on startup. It looks in:
   - `%APPDATA%\\Roaming\\Enshrouded` (Windows)


### PR DESCRIPTION
## Summary
- add argparse-powered CLI allowing `--source`, `--target`, and optional `--save-dir`
- skip GUI when CLI arguments provided and duplicate worlds directly
- document command-line usage in README

## Testing
- `python -m py_compile world_duplicator.py`
- `python world_duplicator.py --help`
- `python world_duplicator.py --source foo --target bar` *(fails to detect save dir as expected)*

------
https://chatgpt.com/codex/tasks/task_e_68add40f4d24832c9329787bee6720cc