### PR TITLE
feat: add yes flag for unattended CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ Provide a custom save directory if it cannot be auto-detected:
 python world_duplicator.py --source <src_id> --target <dst_id> --save-dir "/path/to/Enshrouded"
 ```
 
+Run unattended without confirmation prompts by adding the `--yes` flag:
+
+```shell
+python world_duplicator.py --source <src_id> --target <dst_id> --yes
+```
+
 Both `--source` and `--target` must be valid world IDs. The script will report success or failure via the command line.
 
 ### **Using the program:**


### PR DESCRIPTION
## Summary
- add `--yes` flag to automatically confirm world duplication in CLI mode
- guard GUI confirmations so prompts appear only when interactive
- document `--yes` flag for unattended automation

## Testing
- `python -m py_compile world_duplicator.py`
- `python world_duplicator.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68add58330a4832cbf5fc458be11dcda