### PR TITLE
Add world listing flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ Run unattended without confirmation prompts by adding the `--yes` flag:
 python world_duplicator.py --source <src_id> --target <dst_id> --yes
 ```
 
+List available worlds and exit:
+
+```shell
+python world_duplicator.py --list
+```
+
+Include `--save-dir` if the location cannot be auto-detected:
+
+```shell
+python world_duplicator.py --list --save-dir "/path/to/Enshrouded"
+```
+
 Both `--source` and `--target` must be valid world IDs. The script will report success or failure via the command line.
 
 ### **Using the program:**

--- a/world_duplicator.py
+++ b/world_duplicator.py
@@ -451,8 +451,32 @@ def main():
         action="store_true",
         help="Automatically answer yes to confirmation prompts",
     )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List available worlds and exit",
+    )
 
     args = parser.parse_args()
+
+    if args.list:
+        save_dir = args.save_dir
+        if not save_dir:
+            logging.error("Save directory not specified and could not be guessed")
+            print("Error: save directory not specified and could not be guessed.")
+            sys.exit(1)
+
+        wm = WorldManager()
+        try:
+            wm.set_save_directory(save_dir)
+        except Exception as e:
+            logging.error(f"Failed to load save directory: {e}")
+            print(f"Error: {e}")
+            sys.exit(1)
+
+        for display_name, world_id in wm.scan_worlds():
+            print(f"{display_name}: {world_id}")
+        sys.exit(0)
 
     if args.source and args.target:
         save_dir = args.save_dir


### PR DESCRIPTION
## Summary
- add `--list` CLI flag to display all available worlds without launching the GUI
- document new listing option in README

## Testing
- `python3 -m py_compile world_duplicator.py`
- `python3 world_duplicator.py --help` *(fails: ModuleNotFoundError: No module named 'tkinter')*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68add737fa04832c9ed83a64bcaa4bcb