### PR TITLE
Package world duplicator and document pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,23 @@ Before running this tool, ensure you have:
 
 ---
 
-## **Installation**  
-1. **Save** the `world_duplicator.py` script to any location on your computer.  
-2. Ensure your system meets the requirements below.  
+## **Installation**
+
+Install using pip:
+```shell
+pip install enshrouded-world-duplicator
+```
+
+To install from a cloned repository, run:
+```shell
+pip install .
+```
+
+This provides the `world-duplicator` command.
+
+### **Manual installation**
+1. **Save** the `world_duplicator.py` script to any location on your computer.
+2. Ensure your system meets the requirements below.
 
 ### **Windows**  
 - Python’s **Tkinter** library is included by default.  

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "enshrouded-world-duplicator"
+version = "0.1.0"
+description = "Duplicate Enshrouded game worlds via CLI or GUI"
+readme = "README.md"
+license = { file = "LICENSE" }
+requires-python = ">=3.10"
+authors = [{name = "Tony"}]
+
+[project.scripts]
+world-duplicator = "world_duplicator:main"
+
+[tool.setuptools]
+py-modules = ["world_duplicator"]


### PR DESCRIPTION
## Summary
- add `pyproject.toml` with project metadata and a console script entry point
- document pip-based installation in README

## Testing
- `python -m pip install .` *(fails: Could not find a version that satisfies the requirement setuptools>=61.0)*
- `python world_duplicator.py --help`

------
https://chatgpt.com/codex/tasks/task_e_68add7f22928832ca8a5458974ce0ebe