### PR TITLE
Add pytest-based tests for world operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,11 +191,20 @@ If you run into errors, check the logs:
 - Uses **Python's built-in libraries** (no external dependencies required).  
 - Performs **safe file operations** with error handling.  
 - Maintains **all world configurations and metadata**.  
-- Works with the **latest version of Enshrouded** (as of **February 2024**).  
+- Works with the **latest version of Enshrouded** (as of **February 2024**).
+ 
+---
+
+## **Running Tests**
+This project uses `pytest` for its test suite. Run the tests from the repository root with:
+
+```shell
+pytest
+```
 
 ---
 
-## **Final Reminder**  
+## **Final Reminder**
 This tool **overwrites the target world completely**. Double-check your selections before confirming. **Back up your files** to avoid irreversible changes.  
 
 Enjoy duplicating your Enshrouded worlds safely! 🚀

--- a/tests/test_world_manager.py
+++ b/tests/test_world_manager.py
@@ -1,0 +1,95 @@
+import json
+from pathlib import Path
+
+import pytest
+
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import world_duplicator
+from world_duplicator import WorldManager
+
+
+@pytest.fixture
+def sample_save_dir(tmp_path: Path) -> Path:
+    """Create a fake save directory with two worlds and metadata."""
+    metadata = {
+        "worlds": [
+            {
+                "id": "world1",
+                "name": "World One",
+                "createdAt": 0,
+                "lastPlayed": 0,
+            },
+            {
+                "id": "world2",
+                "name": "World Two",
+                "createdAt": 0,
+                "lastPlayed": 0,
+            },
+        ]
+    }
+    (tmp_path / "enshrouded_user.json").write_text(json.dumps(metadata))
+
+    # World 1 files
+    (tmp_path / "world1-index").write_text(
+        json.dumps({"id": "world1", "time": 0, "deleted": False, "latest": 1})
+    )
+    (tmp_path / "world1-data").write_text("source")
+
+    # World 2 files
+    (tmp_path / "world2-index").write_text(
+        json.dumps({"id": "world2", "time": 0, "deleted": False, "latest": 2})
+    )
+    (tmp_path / "world2-data").write_text("target")
+
+    return tmp_path
+
+
+def test_set_save_directory(sample_save_dir: Path) -> None:
+    wm = WorldManager()
+    wm.set_save_directory(sample_save_dir)
+
+    assert wm.save_dir == sample_save_dir
+    assert "world1" in wm.worlds and "world2" in wm.worlds
+
+
+def test_scan_worlds(sample_save_dir: Path) -> None:
+    wm = WorldManager()
+    wm.set_save_directory(sample_save_dir)
+    world_list = wm.scan_worlds()
+
+    ids = {world_id for _, world_id in world_list}
+    assert ids == {"world1", "world2"}
+
+
+def test_duplicate_world(sample_save_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    wm = WorldManager()
+    wm.set_save_directory(sample_save_dir)
+
+    # Freeze time for predictable results
+    monkeypatch.setattr(world_duplicator.time, "time", lambda: 1234567890)
+    monkeypatch.setattr(
+        world_duplicator.time, "strftime", lambda fmt: "20200101000000"
+    )
+
+    backup_dir = wm.duplicate_world("world1", "world2")
+    assert backup_dir is not None
+    assert backup_dir.is_dir()
+
+    # Original target files should be in the backup directory
+    assert (backup_dir / "world2-data").read_text() == "target"
+    assert (backup_dir / "world2-index").exists()
+
+    # Target files should now match source contents
+    assert (sample_save_dir / "world2-data").read_text() == "source"
+
+    index_data = json.loads((sample_save_dir / "world2-index").read_text())
+    assert index_data["time"] == 1234567890
+    assert index_data["deleted"] is False
+    assert index_data["latest"] == 1
+
+    metadata = json.loads((sample_save_dir / "enshrouded_user.json").read_text())
+    world2_meta = next(w for w in metadata["worlds"] if w["id"] == "world2")
+    assert world2_meta["name"] == "Copy of World One"
+    assert world2_meta["lastPlayed"] == 1234567890


### PR DESCRIPTION
## Summary
- add pytest suite with fixtures simulating save directories
- test `set_save_directory`, `scan_worlds`, and `duplicate_world`
- document how to run tests in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68add8d0030c832cbbcc8d4255d303d8