### PR TITLE
Add module entry point for world_duplicator

### DIFF
--- a/src/world_duplicator/__main__.py
+++ b/src/world_duplicator/__main__.py
@@ -1,0 +1,4 @@
+from . import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `__main__.py` to call package's `main`

## Testing
- `PYTHONPATH=src python -m world_duplicator --help`
- `PYTHONPATH=src pytest`
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=61.0)*

------
https://chatgpt.com/codex/tasks/task_e_68ade6ece06c832cb6fa3f32fcf23839